### PR TITLE
Added #include <avr/wdt.h> to SoftReset.h

### DIFF
--- a/SoftReset.h
+++ b/SoftReset.h
@@ -22,6 +22,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #ifndef _SOFT_RESTART_H
 #define _SOFT_RESTART_H
 
+#include <avr/wdt.h>
+
 #define soft_restart()        \
 do                          \
 {                           \


### PR DESCRIPTION
Hello,

I had trouble using soft_restart() in my code because of the error:

```
ihlc.ino: In function 'void handlePanelButtons()':
ihlc:88: error: 'WDTO_15MS' was not declared in this scope
ihlc:88: error: 'wdt_enable' was not declared in this scope
```

Adding `#include <avr/wdt.h>` to SoftReset.h solved the problem - which I think is preferable to having to know to also include avr/wdt.h in the main code.

nick.
